### PR TITLE
Update dependency flutter_colorpicker in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  flutter_colorpicker: ^0.4.0
+  flutter_colorpicker: ^0.5.0
   shared_preferences: ^2.0.6
 
 dev_dependencies:


### PR DESCRIPTION
Hi 👋 

according to [this ](https://github.com/mchome/flutter_colorpicker/issues/48#issuecomment-861138447) upstream issue a update to `5.0.0` of the dependency [`flutter_colorpicker`](https://github.com/mchome/flutter_colorpicker) might solve a issue caused by new(er) Flutter versions.

I'd be very grateful if you could look into this any time soon.

Just wanted to say that this is a great package 👍 I'm currently learning about Flutter and really love it.

Regards, Jean-Luc